### PR TITLE
Fixes a bug when using non-default image sizes

### DIFF
--- a/model.py
+++ b/model.py
@@ -14,6 +14,7 @@ class cyclegan(object):
     def __init__(self, sess, args):
         self.sess = sess
         self.batch_size = args.batch_size
+        self.load_size = args.load_size
         self.image_size = args.fine_size
         self.input_c_dim = args.input_nc
         self.output_c_dim = args.output_nc
@@ -210,7 +211,7 @@ class cyclegan(object):
         np.random.shuffle(dataA)
         np.random.shuffle(dataB)
         batch_files = list(zip(dataA[:self.batch_size], dataB[:self.batch_size]))
-        sample_images = [load_train_data(batch_file, is_testing=True) for batch_file in batch_files]
+        sample_images = [load_train_data(batch_file, self.load_size, self.image_size, is_testing=True) for batch_file in batch_files]
         sample_images = np.array(sample_images).astype(np.float32)
 
         fake_A, fake_B = self.sess.run(


### PR DESCRIPTION
Came across a bug when using smaller picture sizes than 256. The function load_train_data method wasn't given the picture shape that the network was built with, which resulted in incompatible tensor shapes.