### PR TITLE
use imageio if (deprecated) scipy.misc.imread unavailable

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ tensorflow-gpu
 numpy
 scipy
 pillow
+imageio

--- a/utils.py
+++ b/utils.py
@@ -7,6 +7,10 @@ import pprint
 import scipy.misc
 import numpy as np
 import copy
+try:
+    _imread = scipy.misc.imread
+except AttributeError:
+    from imageio import imread as _imread
 
 pp = pprint.PrettyPrinter()
 
@@ -79,9 +83,9 @@ def save_images(images, size, image_path):
 
 def imread(path, is_grayscale = False):
     if (is_grayscale):
-        return scipy.misc.imread(path, flatten = True).astype(np.float)
+        return _imread(path, flatten=True).astype(np.float)
     else:
-        return scipy.misc.imread(path, mode='RGB').astype(np.float)
+        return _imread(path, mode='RGB').astype(np.float)
 
 def merge_images(images, size):
     return inverse_transform(images)


### PR DESCRIPTION
From [scipy.misc.imread reference](https://docs.scipy.org/doc/scipy/reference/generated/scipy.misc.imread.html):
> `imread` is deprecated! `imread` is deprecated in SciPy 1.0.0, and will be removed in 1.2.0. Use `imageio.imread` instead.

So if SciPy is up-to-date, `scipy.misc.imread` doesn't exist anymore.